### PR TITLE
Update EKS cluster to allow private ones

### DIFF
--- a/terraform/computing/eks/aws/README.md
+++ b/terraform/computing/eks/aws/README.md
@@ -3,7 +3,13 @@
 This module is responsible of EKS cluster & worker nodes deployment in AWS.
 It will deploy it in a public subnet.
 
-TODO: Add choice to deploy in private subnets.
+By default the module will spawn an EKS with public & private endpoint.
+This can be changed with the following variables (bools):
+
+* `eks_private_access`
+* `eks_public_access`
+
+> ⚠️ A private EKS endpoint will prevent Terraform from deploy directly in the cluster since the API will be in a private zone therefor not reachable from internet.
 
 ## How to
 
@@ -33,14 +39,18 @@ Then you can call this module
 module "cluster" {
   source = "../../aws/"
 
-  eks_cluster_name        = data.terraform_remote_state.network.outputs.eks_cluster_name
-  eks_cluster_subnets_ids = data.terraform_remote_state.network.outputs.public_subnet_ids
+  eks_cluster_name                = data.terraform_remote_state.network.outputs.eks_cluster_name
+  eks_cluster_public_subnets_ids  = data.terraform_remote_state.network.outputs.public_subnet_ids
+  eks_cluster_private_subnets_ids = data.terraform_remote_state.network.outputs.private_subnet_ids
 
   eks_group_nodes_tags = {
     "kubernetes.io/cluster/${data.terraform_remote_state.network.outputs.eks_cluster_name}"     = "owned"
     "k8s.io/cluster-autoscaler/${data.terraform_remote_state.network.outputs.eks_cluster_name}" = "owned"
     "k8s.io/cluster-autoscaler/enabled"                                                         = "true"
   }
+
+  eks_private_access = true
+  eks_public_access  = true
 
   vpc_id = data.terraform_remote_state.network.outputs.vpc_id
 }

--- a/terraform/computing/eks/aws/eks.tf
+++ b/terraform/computing/eks/aws/eks.tf
@@ -3,9 +3,9 @@ resource "aws_eks_cluster" "this" {
   role_arn = aws_iam_role.eks_role.arn
 
   vpc_config {
-    subnet_ids              = var.eks_cluster_subnets_ids
-    endpoint_private_access = true
-    endpoint_public_access  = true
+    subnet_ids              = local.subnet_ids
+    endpoint_private_access = var.eks_private_access
+    endpoint_public_access  = var.eks_public_access
     security_group_ids = [
       aws_security_group.eks.id,
       aws_security_group.worker_nodes.id,

--- a/terraform/computing/eks/aws/locals.tf
+++ b/terraform/computing/eks/aws/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  subnet_ids = (
+    var.eks_private_access && !var.eks_public_access ? var.eks_cluster_private_subnets_ids :
+    !var.eks_private_access && var.eks_public_access ? var.eks_cluster_public_subnets_ids :
+    var.eks_private_access && var.eks_public_access ? concat(var.eks_cluster_private_subnets_ids, var.eks_cluster_public_subnets_ids) :
+    []
+  )
+}

--- a/terraform/computing/eks/aws/nodes.tf
+++ b/terraform/computing/eks/aws/nodes.tf
@@ -8,7 +8,7 @@ resource "aws_eks_node_group" "this" {
   node_role_arn   = aws_iam_role.eks_workers.arn
   version         = aws_eks_cluster.this.version
   release_version = nonsensitive(data.aws_ssm_parameter.eks_ami_release_version.value)
-  subnet_ids      = var.eks_cluster_subnets_ids
+  subnet_ids      = local.subnet_ids
   capacity_type   = var.eks_worker_capacity_type
 
   scaling_config {

--- a/terraform/computing/eks/aws/variables.tf
+++ b/terraform/computing/eks/aws/variables.tf
@@ -4,8 +4,13 @@ variable "eks_cluster_name" {
   default     = "eks-cluster"
 }
 
-variable "eks_cluster_subnets_ids" {
-  description = "The IDs of the subnets to use for the EKS cluster"
+variable "eks_cluster_public_subnets_ids" {
+  description = "The IDs of the public subnets to use for the EKS cluster"
+  type        = list(string)
+}
+
+variable "eks_cluster_private_subnets_ids" {
+  description = "The IDs of the private subnets to use for the EKS cluster"
   type        = list(string)
 }
 
@@ -13,6 +18,18 @@ variable "eks_group_nodes_tags" {
   description = "A map of tags to assign to the EKS workers"
   type        = map(string)
   default     = {}
+}
+
+variable "eks_private_access" {
+  description = "Indicates whether or not the EKS cluster has private access"
+  type        = bool
+  default     = false
+}
+
+variable "eks_public_access" {
+  description = "Indicates whether or not the EKS cluster has public access"
+  type        = bool
+  default     = true
 }
 
 variable "eks_worker_capacity_type" {

--- a/terraform/computing/eks/tests/02-cluster/main.tf
+++ b/terraform/computing/eks/tests/02-cluster/main.tf
@@ -1,14 +1,18 @@
 module "cluster" {
   source = "../../aws/"
 
-  eks_cluster_name        = data.terraform_remote_state.network.outputs.eks_cluster_name
-  eks_cluster_subnets_ids = data.terraform_remote_state.network.outputs.public_subnet_ids
+  eks_cluster_name                = data.terraform_remote_state.network.outputs.eks_cluster_name
+  eks_cluster_public_subnets_ids  = data.terraform_remote_state.network.outputs.public_subnet_ids
+  eks_cluster_private_subnets_ids = data.terraform_remote_state.network.outputs.private_subnet_ids
 
   eks_group_nodes_tags = {
     "kubernetes.io/cluster/${data.terraform_remote_state.network.outputs.eks_cluster_name}"     = "owned"
     "k8s.io/cluster-autoscaler/${data.terraform_remote_state.network.outputs.eks_cluster_name}" = "owned"
     "k8s.io/cluster-autoscaler/enabled"                                                         = "true"
   }
+
+  eks_private_access = true
+  eks_public_access  = true
 
   vpc_id = data.terraform_remote_state.network.outputs.vpc_id
 }

--- a/terraform/computing/eks/tests/Makefile
+++ b/terraform/computing/eks/tests/Makefile
@@ -13,11 +13,11 @@ check_env:
 
 plan: check_env
 	@cd 01-network && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform validate && \
 	terraform apply --auto-approve && \
 	cd ../02-cluster && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform validate && \
 	terraform plan && \
 	cd ../01-network && \
@@ -26,18 +26,18 @@ plan: check_env
 
 test: check_env
 	@cd 01-network && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform validate && \
 	terraform apply --auto-approve && \
 	cd ../02-cluster && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform validate && \
 	terraform plan -out=plan  && \
 	terraform show -json plan > ../plan.json && \
 	rm plan && \
 	terraform apply --auto-approve && \
 	cd ../03-deployment && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform validate && \
 	terraform apply --auto-approve && \
 	cd .. && \
@@ -61,11 +61,11 @@ test: check_env
 
 destroy:
 	@cd 03-deployment && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform destroy --auto-approve && \
 	cd ../02-cluster && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform destroy --auto-approve && \
 	cd ../01-network && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform destroy --auto-approve

--- a/terraform/computing/instances/tests/makefile
+++ b/terraform/computing/instances/tests/makefile
@@ -13,11 +13,11 @@ check_env:
 
 plan: check_env
 	@cd 01-network && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform validate && \
 	terraform apply --auto-approve && \
 	cd ../02-instances && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform validate && \
 	terraform plan && \
 	cd ../01-network && \
@@ -26,11 +26,11 @@ plan: check_env
 
 test: check_env
 	@cd 01-network && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform validate && \
 	terraform apply --auto-approve && \
 	cd ../02-instances && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform validate && \
 	terraform plan -out=plan  && \
 	terraform show -json plan > ../plan.json && \
@@ -51,8 +51,8 @@ test: check_env
 
 destroy:
 	@cd 02-instances && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform destroy --auto-approve && \
 	cd ../01-network && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform destroy --auto-approve

--- a/terraform/network/aws/nat.tf
+++ b/terraform/network/aws/nat.tf
@@ -1,7 +1,7 @@
 resource "aws_nat_gateway" "this" {
   count         = var.create_private_subnet ? 1 : 0
   allocation_id = aws_eip.this.id
-  subnet_id     = aws_subnet.private[0].id
+  subnet_id     = aws_subnet.public[0].id
 }
 
 resource "aws_route_table" "private_route_table" {

--- a/terraform/network/tests/Makefile
+++ b/terraform/network/tests/Makefile
@@ -13,14 +13,14 @@ check_env:
 
 plan: check_env
 	@cd 01-network && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform validate && \
 	terraform plan && \
 	echo "01-network: SHOULD BE OK"
 
 test: check_env
 	@cd 01-network && \
-	terraform init && \
+	terraform init -upgrade && \
 	terraform validate && \
 	terraform plan -out=plan  && \
 	terraform show -json plan > ../plan.json && \


### PR DESCRIPTION
This PR allows to spawn private EKS clusters.

Note it can't be tested since Terraform won't be able to reach the EKS API (that will be in a private zone)